### PR TITLE
Added registry events for hide and show

### DIFF
--- a/app/public/electron.js
+++ b/app/public/electron.js
@@ -53,7 +53,9 @@ function createWindow() {
 
   win.once("ready-to-show", () => win.show());
 
-  win.on("closed", () => (win = null));
+  win.on("closed", () => {
+    (win = null)
+  });
 
   let blockShortcuts = ["CommandOrControl+R", "CommandOrControl+Shift+R", "CommandOrControl+Alt+Q"];
 
@@ -63,6 +65,14 @@ function createWindow() {
             globalShortcut.register(key, () => {})
         ));
     win.on("blur", () =>
+        blockShortcuts.map((key) =>
+            globalShortcut.unregister(key)
+        ));
+    win.on("show", () =>
+        blockShortcuts.map((key) =>
+            globalShortcut.register(key, () => {})
+        ));
+    win.on("hide", () =>
         blockShortcuts.map((key) =>
             globalShortcut.unregister(key)
         ));


### PR DESCRIPTION
This fixes the keybinds staying when you click x on the application.

It doesn't matter if register and focus are both called as they will silently fail if something is already registered.